### PR TITLE
Include "err.h" to be able to use `warnx()`

### DIFF
--- a/argtable3.c
+++ b/argtable3.c
@@ -383,6 +383,8 @@ static void warnx(const char *fmt, ...)
 	fprintf(stderr, "\n");
 }
 
+#else
+#include <err.h>
 #endif /*_WIN32*/
 
 


### PR DESCRIPTION
Otherwise, we get a warning about `warnx()` not being defined.