### PR TITLE
Fixed format string misuse (V618) and not zero-terminated string (C6053) warnings in win32 'warnx' implementation

### DIFF
--- a/argtable3.c
+++ b/argtable3.c
@@ -354,6 +354,7 @@ static const char illoptchar[] = "unknown option -- %c";
 static const char illoptstring[] = "unknown option -- %s";
 
 
+
 #ifdef _WIN32
 
 /* Windows needs warnx().  We change the definition though:
@@ -367,24 +368,26 @@ static const char illoptstring[] = "unknown option -- %s";
 #include <stdarg.h>
 
 extern char opterrmsg[128];
-char opterrmsg[128]; /* last error message is stored here */
+char opterrmsg[128]; /* buffer for the last error message */
 
 static void warnx(const char *fmt, ...)
 {
 	va_list ap;
 	va_start(ap, fmt);
+    /*
+    Make sure opterrmsg is always zero-terminated despite the _vsnprintf()
+    implementation specifics and manually suppress the warning.
+    */
+    memset(opterrmsg, 0, sizeof opterrmsg);
 	if (fmt != NULL)
-		_vsnprintf(opterrmsg, 128, fmt, ap);
-	else
-		opterrmsg[0]='\0';
+		_vsnprintf(opterrmsg, sizeof(opterrmsg) - 1, fmt, ap);
 	va_end(ap);
 
-	fprintf(stderr, opterrmsg);
-	fprintf(stderr, "\n");
+#pragma warning(suppress: 6053)
+	fprintf(stderr, "%s\n", opterrmsg);
 }
 
 #endif /*_WIN32*/
-
 
 
 /*


### PR DESCRIPTION
Both warnings are false positive, since `opterrmsg` buffer is controled solely by the `warnx` function and `_vsnprintf` appears to be zero-terminating its output as the documentation says. I've changed the `fprintf` call so it guards from a formatting string input to make V618 of the PVS Studio happy, manually zeroed the buffer before `_vsnprintf` call and limited it's output size to (buffer size - 1) to guarantee the output is always zero-terminated despite the implementation and suppressed the warning C6053 of the VS Code Analysis.