### PR TITLE
Unused rcsid variable throws compile error with newest GCC 7.2.0

### DIFF
--- a/argtable3.c
+++ b/argtable3.c
@@ -283,9 +283,8 @@ extern   char *suboptarg;               /* getsubopt(3) external variable */
  * Materiel Command, USAF, under agreement number F39502-99-1-0512.
  */
 
-#ifndef lint
-static const char rcsid[]="$Id: getopt_long.c,v 1.1 2009/10/16 19:50:28 rodney Exp rodney $";
-#endif /* lint */
+// $Id: getopt_long.c,v 1.1 2009/10/16 19:50:28 rodney Exp rodney $"
+
 /*-
  * Copyright (c) 2000 The NetBSD Foundation, Inc.
  * All rights reserved.


### PR DESCRIPTION
Hello @tomghuang, this is a nice and handy project!

I hope this change does not trouble your linting routines too much, but the reason I'm requesting it is detailed below:

```
CC build/console/argtable3/argtable3.o
/Users/romanvg/dev/espressif/esp-idf/components/console/argtable3/argtable3.c: In function 'trex_charnode':
/Users/romanvg/dev/espressif/esp-idf/components/console/argtable3/argtable3.c:3068:7: warning: this statement may fall through [-Wimplicit-fallthrough=]
     if(!isclass) {
       ^
/Users/romanvg/dev/espressif/esp-idf/components/console/argtable3/argtable3.c:3074:4: note: here
    default:
    ^~~~~~~
At top level:
/Users/romanvg/dev/espressif/esp-idf/components/console/argtable3/argtable3.c:273:19: error: 'rcsid' defined but not used [-Werror=unused-const-variable=]
 static const char rcsid[]="$Id: getopt_long.c,v 1.1 2009/10/16 19:50:28 rodney Exp rodney $";
                   ^~~~~
/Users/romanvg/dev/espressif/esp-idf/components/console/argtable3/argtable3.c: In function 'trex_compile':
/Users/romanvg/dev/espressif/esp-idf/components/console/argtable3/argtable3.c:3466:8: warning: variable 'exp' might be clobbered by 'longjmp' or 'vfork' [-Wclobbered]
  TRex *exp = (TRex *)malloc(sizeof(TRex));
        ^~~
cc1: some warnings being treated as errors
make[1]: *** [argtable3/argtable3.o] Error 1
make: *** [component-console-build] Error 2
```

I'm trying to get this change included as a result of cleaning up for the following pull request:

https://github.com/espressif/esp-idf/pull/1163/files#diff-d5ecc885891c22ec8da78d6b54dc63b5L273

Let me know what you think about it, thanks!