### PR TITLE
Explicit downcast from long int, allows clean build under clang.

### DIFF
--- a/argtable3.c
+++ b/argtable3.c
@@ -2298,7 +2298,7 @@ static int arg_int_scanfn(struct arg_int *parent, const char *argval)
 
         /* if success then store result in parent->ival[] array */
         if (errorcode == 0)
-            parent->ival[parent->count++] = val;
+            parent->ival[parent->count++] = (int)val;
     }
 
     /* printf("%s:scanfn(%p,%p) returns %d\n",__FILE__,parent,argval,errorcode); */


### PR DESCRIPTION
ival is a *int type, val is long int, the downcast is happening regardless, this just makes it explicit for LLVM (inc MacOS).