### PR TITLE
Make argtable3 ANSI-C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ################################################################################
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 2.8)
 
 set(ARGTABLE3_PROJECT_NAME "argtable3")
 set(ARGTABLE3_PACKAGE_NAME "Argtable3")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,15 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ################################################################################
 
+set(CMAKE_C_FLAGS                   "${CMAKE_C_FLAGS} -std=c89 -Wpedantic -Werror")
+set(CMAKE_C_FLAGS                   "${CMAKE_C_FLAGS} -Wall")
+set(CMAKE_C_FLAGS                   "${CMAKE_C_FLAGS} -Wextra")
+# Honestly, I don't know how to fix arg_int.c without too many code changes. Perhaps someone can fix `strtol0X`?
+# In the meanwhile, this flag will ignore reporting errors in that function.
+set(CMAKE_C_FLAGS                   "${CMAKE_C_FLAGS} -Wno-discarded-qualifiers")
+
+add_definitions(-D_XOPEN_SOURCE=700)
+
 if(WIN32)
   set(COMPANY_NAME "The Argtable3 Project")
   set(FILE_DESC "ANSI C command-line parsing library")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,12 +28,9 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ################################################################################
 
-set(CMAKE_C_FLAGS                   "${CMAKE_C_FLAGS} -std=c89 -Wpedantic -Werror")
+set(CMAKE_C_FLAGS                   "${CMAKE_C_FLAGS} -std=c89 -Wpedantic")
 set(CMAKE_C_FLAGS                   "${CMAKE_C_FLAGS} -Wall")
 set(CMAKE_C_FLAGS                   "${CMAKE_C_FLAGS} -Wextra")
-# Honestly, I don't know how to fix arg_int.c without too many code changes. Perhaps someone can fix `strtol0X`?
-# In the meanwhile, this flag will ignore reporting errors in that function.
-set(CMAKE_C_FLAGS                   "${CMAKE_C_FLAGS} -Wno-discarded-qualifiers")
 
 add_definitions(-D_XOPEN_SOURCE=700)
 

--- a/src/arg_dbl.c
+++ b/src/arg_dbl.c
@@ -117,6 +117,8 @@ struct arg_dbl* arg_dbl1(const char* shortopts, const char* longopts, const char
 struct arg_dbl* arg_dbln(const char* shortopts, const char* longopts, const char* datatype, int mincount, int maxcount, const char* glossary) {
     size_t nbytes;
     struct arg_dbl* result;
+    size_t addr;
+    size_t rem;
 
     /* foolproof things by ensuring maxcount is not less than mincount */
     maxcount = (maxcount < mincount) ? mincount : maxcount;
@@ -125,9 +127,6 @@ struct arg_dbl* arg_dbln(const char* shortopts, const char* longopts, const char
              + (maxcount + 1) * sizeof(double); /* storage for dval[maxcount] array plus one extra for padding to memory boundary */
 
     result = (struct arg_dbl*)xmalloc(nbytes);
-
-    size_t addr;
-    size_t rem;
 
     /* init the arg_hdr struct */
     result->hdr.flag = ARG_HASVALUE;

--- a/src/arg_dstr.c
+++ b/src/arg_dstr.c
@@ -172,7 +172,7 @@ char* arg_dstr_cstr(arg_dstr_t ds) /* Interpreter whose result to return. */
     return ds->data;
 }
 
-void arg_dstr_cat(arg_dstr_t ds, char* str) {
+void arg_dstr_cat(arg_dstr_t ds, const char* str) {
     setup_append_buf(ds, (int)strlen(str) + 1);
     strncat(ds->data, str, strlen(str));
 }

--- a/src/arg_file.c
+++ b/src/arg_file.c
@@ -164,6 +164,7 @@ struct arg_file* arg_file1(const char* shortopts, const char* longopts, const ch
 struct arg_file* arg_filen(const char* shortopts, const char* longopts, const char* datatype, int mincount, int maxcount, const char* glossary) {
     size_t nbytes;
     struct arg_file* result;
+    int i;
 
     /* foolproof things by ensuring maxcount is not less than mincount */
     maxcount = (maxcount < mincount) ? mincount : maxcount;
@@ -174,8 +175,6 @@ struct arg_file* arg_filen(const char* shortopts, const char* longopts, const ch
              + sizeof(char*) * maxcount; /* storage for extension[maxcount] array */
 
     result = (struct arg_file*)xmalloc(nbytes);
-
-    int i;
 
     /* init the arg_hdr struct */
     result->hdr.flag = ARG_HASVALUE;

--- a/src/arg_hashtable.c
+++ b/src/arg_hashtable.c
@@ -86,7 +86,7 @@ static const unsigned int primes[] = {53,       97,       193,      389,       7
 const unsigned int prime_table_length = sizeof(primes) / sizeof(primes[0]);
 const float max_load_factor = (float)0.65;
 
-static unsigned int enhanced_hash(arg_hashtable_t* h, void* k) {
+static unsigned int enhanced_hash(arg_hashtable_t* h, const void* k) {
     /*
      * Aim to protect against poor hash functions by adding logic here.
      * The logic is taken from Java 1.4 hash table source.
@@ -101,9 +101,9 @@ static unsigned int enhanced_hash(arg_hashtable_t* h, void* k) {
 
 static unsigned int index_for(unsigned int tablelength, unsigned int hashvalue) {
     return (hashvalue % tablelength);
-};
+}
 
-arg_hashtable_t* arg_hashtable_create(unsigned int minsize, unsigned int (*hashfn)(void*), int (*eqfn)(void*, void*)) {
+arg_hashtable_t* arg_hashtable_create(unsigned int minsize, unsigned int (*hashfn)(const void*), int (*eqfn)(const void*, const void*)) {
     arg_hashtable_t* h;
     unsigned int pindex;
     unsigned int size = primes[0];
@@ -198,7 +198,7 @@ void arg_hashtable_insert(arg_hashtable_t* h, void* k, void* v) {
     h->entrycount++;
 }
 
-void* arg_hashtable_search(arg_hashtable_t* h, void* k) {
+void* arg_hashtable_search(arg_hashtable_t* h, const void* k) {
     struct arg_hashtable_entry* e;
     unsigned int hashvalue;
     unsigned int index;
@@ -215,7 +215,7 @@ void* arg_hashtable_search(arg_hashtable_t* h, void* k) {
     return NULL;
 }
 
-void arg_hashtable_remove(arg_hashtable_t* h, void* k) {
+void arg_hashtable_remove(arg_hashtable_t* h, const void* k) {
     /*
      * TODO: consider compacting the table when the load factor drops enough,
      *       or provide a 'compact' method.

--- a/src/arg_int.c
+++ b/src/arg_int.c
@@ -55,7 +55,7 @@ static void arg_int_resetfn(struct arg_int* parent) {
 /* eg: to parse oct str="+0o12324", specify X='O' and base=8.       */
 /* eg: to parse bin str="-0B01010", specify X='B' and base=2.       */
 /* Failure of conversion is indicated by result where *endptr==str. */
-static long int strtol0X(const char* str, const char** endptr, char X, int base) {
+static long int strtol0X(const char* str, char** endptr, char X, int base) {
     long int val;          /* stores result */
     int s = 1;             /* sign is +1 or -1 */
     const char* ptr = str; /* ptr to current position in str */
@@ -149,7 +149,7 @@ static int arg_int_scanfn(struct arg_int* parent, const char* argval) {
         parent->count++;
     } else {
         long int val;
-        const char* end;
+        char* end;
 
         /* attempt to extract hex integer (eg: +0x123) from argval into val conversion */
         val = strtol0X(argval, &end, 'X', 16);

--- a/src/arg_rex.c
+++ b/src/arg_rex.c
@@ -157,12 +157,14 @@ static int arg_rex_scanfn(struct arg_rex* parent, const char* argval) {
 
 static int arg_rex_checkfn(struct arg_rex* parent) {
     int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
-    // struct privhdr *priv = (struct privhdr*)parent->hdr.priv;
+#if 0
+    struct privhdr *priv = (struct privhdr*)parent->hdr.priv;
 
     /* free the regex "program" we constructed in resetfn */
-    // regfree(&(priv->regex));
+    regfree(&(priv->regex));
 
     /*printf("%s:checkfn(%p) returns %d\n",__FILE__,parent,errorcode);*/
+#endif
     return errorcode;
 }
 
@@ -192,9 +194,11 @@ static void arg_rex_errorfn(struct arg_rex* parent, arg_dstr_t ds, int errorcode
             break;
 
         default: {
-            // char errbuff[256];
-            // regerror(errorcode, NULL, errbuff, sizeof(errbuff));
-            // printf("%s\n", errbuff);
+        #if 0
+            char errbuff[256];
+            regerror(errorcode, NULL, errbuff, sizeof(errbuff));
+            printf("%s\n", errbuff);
+        #endif
         } break;
     }
 }
@@ -308,14 +312,14 @@ static const TRexChar* g_nnames[] = {_SC("NONE"),    _SC("OP_GREEDY"), _SC("OP_O
                                      _SC("OP_CHAR"), _SC("OP_EOL"),    _SC("OP_BOL"),    _SC("OP_WB")};
 
 #endif
-#define OP_GREEDY (MAX_CHAR + 1)  // * + ? {n}
+#define OP_GREEDY (MAX_CHAR + 1)  /*  * + ? {n} */
 #define OP_OR (MAX_CHAR + 2)
-#define OP_EXPR (MAX_CHAR + 3)       // parentesis ()
-#define OP_NOCAPEXPR (MAX_CHAR + 4)  // parentesis (?:)
+#define OP_EXPR (MAX_CHAR + 3)       /* parentesis () */
+#define OP_NOCAPEXPR (MAX_CHAR + 4)  /* parentesis (?:) */
 #define OP_DOT (MAX_CHAR + 5)
 #define OP_CLASS (MAX_CHAR + 6)
 #define OP_CCLASS (MAX_CHAR + 7)
-#define OP_NCLASS (MAX_CHAR + 8)  // negates class the [^
+#define OP_NCLASS (MAX_CHAR + 8)  /* negates class the [^ */
 #define OP_RANGE (MAX_CHAR + 9)
 #define OP_CHAR (MAX_CHAR + 10)
 #define OP_EOL (MAX_CHAR + 11)
@@ -742,7 +746,7 @@ static const TRexChar* trex_matchnode(TRex* exp, TRexNode* node, const TRexChar*
     TRexNodeType type = node->type;
     switch (type) {
         case OP_GREEDY: {
-            // TRexNode *greedystop = (node->next != -1) ? &exp->_nodes[node->next] : NULL;
+            /* TRexNode *greedystop = (node->next != -1) ? &exp->_nodes[node->next] : NULL; */
             TRexNode* greedystop = NULL;
             int p0 = (node->right >> 16) & 0x0000FFFF, p1 = node->right & 0x0000FFFF, nmaches = 0;
             const TRexChar *s = str, *good = str;
@@ -760,8 +764,8 @@ static const TRexChar* trex_matchnode(TRex* exp, TRexNode* node, const TRexChar*
                 nmaches++;
                 good = s;
                 if (greedystop) {
-                    // checks that 0 matches satisfy the expression(if so skips)
-                    // if not would always stop(for instance if is a '?')
+                    /* checks that 0 matches satisfy the expression(if so skips) */
+                    /* if not would always stop(for instance if is a '?') */
                     if (greedystop->type != OP_GREEDY || (greedystop->type == OP_GREEDY && ((greedystop->right >> 16) & 0x0000FFFF) != 0)) {
                         TRexNode* gnext = NULL;
                         if (greedystop->next != -1) {
@@ -771,7 +775,7 @@ static const TRexChar* trex_matchnode(TRex* exp, TRexNode* node, const TRexChar*
                         }
                         stop = trex_matchnode(exp, greedystop, s, gnext);
                         if (stop) {
-                            // if satisfied stop it
+                            /* if satisfied stop it */
                             if (p0 == p1 && p0 == nmaches)
                                 break;
                             else if (nmaches >= p0 && p1 == 0xFFFF)

--- a/src/arg_str.c
+++ b/src/arg_str.c
@@ -102,6 +102,7 @@ struct arg_str* arg_str1(const char* shortopts, const char* longopts, const char
 struct arg_str* arg_strn(const char* shortopts, const char* longopts, const char* datatype, int mincount, int maxcount, const char* glossary) {
     size_t nbytes;
     struct arg_str* result;
+    int i;
 
     /* should not allow this stupid error */
     /* we should return an error code warning this logic error */
@@ -112,8 +113,6 @@ struct arg_str* arg_strn(const char* shortopts, const char* longopts, const char
              + maxcount * sizeof(char*); /* storage for sval[maxcount] array */
 
     result = (struct arg_str*)xmalloc(nbytes);
-
-    int i;
 
     /* init the arg_hdr struct */
     result->hdr.flag = ARG_HASVALUE;

--- a/src/arg_utils.c
+++ b/src/arg_utils.c
@@ -53,11 +53,11 @@ void dbg_printf(const char* fmt, ...) {
 
 static void panic(const char* fmt, ...) {
     va_list args;
+    char* s;
+
     va_start(args, fmt);
     vfprintf(stderr, fmt, args);
     va_end(args);
-
-    char* s;
 
 #if defined(_MSC_VER)
 #pragma warning(push)

--- a/src/argtable3.c
+++ b/src/argtable3.c
@@ -107,6 +107,8 @@ static struct longoptions* alloc_longoptions(struct arg_hdr** table) {
     int noptions = 1;
     size_t longoptlen = 0;
     int tabindex;
+    int option_index = 0;
+    char* store;
 
     /*
      * Determine the total number of option structs required
@@ -133,9 +135,6 @@ static struct longoptions* alloc_longoptions(struct arg_hdr** table) {
     /* (struct longoptions) + (struct options)[noptions] + char[longoptlen] */
     nbytes = sizeof(struct longoptions) + sizeof(struct option) * noptions + longoptlen;
     result = (struct longoptions*)xmalloc(nbytes);
-
-    int option_index = 0;
-    char* store;
 
     result->getoptval = 0;
     result->noptions = noptions;
@@ -183,6 +182,7 @@ static char* alloc_shortoptions(struct arg_hdr** table) {
     char* result;
     size_t len = 2;
     int tabindex;
+    char* res;
 
     /* determine the total number of option chars required */
     for (tabindex = 0; !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {
@@ -192,7 +192,7 @@ static char* alloc_shortoptions(struct arg_hdr** table) {
 
     result = xmalloc(len);
 
-    char* res = result;
+    res = result;
 
     /* add a leading ':' so getopt return codes distinguish    */
     /* unrecognised option and options missing argument values */
@@ -417,6 +417,7 @@ int arg_parse(int argc, char** argv, void** argtable) {
     struct arg_end* endtable;
     int endindex;
     char** argvcopy = NULL;
+    int i;
 
     /*printf("arg_parse(%d,%p,%p)\n",argc,argv,argtable);*/
 
@@ -439,8 +440,6 @@ int arg_parse(int argc, char** argv, void** argtable) {
     }
 
     argvcopy = (char**)xmalloc(sizeof(char*) * (argc + 1));
-
-    int i;
 
     /*
         Fill in the local copy of argv[]. We need a local copy
@@ -881,12 +880,12 @@ void arg_print_glossary(FILE* fp, void** argtable, const char* format) {
  * Author: Uli Fouquet
  */
 static void arg_print_formatted_ds(arg_dstr_t ds, const unsigned lmargin, const unsigned rmargin, const char* text) {
-    assert(strlen(text) < UINT_MAX);
-
     const unsigned int textlen = (unsigned int)strlen(text);
     unsigned int line_start = 0;
     unsigned int line_end = textlen + 1;
     const unsigned int colwidth = (rmargin - lmargin) + 1;
+
+    assert(strlen(text) < UINT_MAX);
 
     /* Someone doesn't like us... */
     if (line_end < line_start) {

--- a/src/argtable3.h
+++ b/src/argtable3.h
@@ -237,12 +237,12 @@ ARG_EXTERN void arg_print_glossary_gnu_ds(arg_dstr_t ds, void** argtable);
 ARG_EXTERN void arg_print_errors_ds(arg_dstr_t ds, struct arg_end* end, const char* progname);
 ARG_EXTERN void arg_freetable(void** argtable, size_t n);
 
-ARG_EXTERN arg_dstr_t arg_dstr_create();
+ARG_EXTERN arg_dstr_t arg_dstr_create(void);
 ARG_EXTERN void arg_dstr_destroy(arg_dstr_t ds);
 ARG_EXTERN void arg_dstr_reset(arg_dstr_t ds);
 ARG_EXTERN void arg_dstr_free(arg_dstr_t ds);
 ARG_EXTERN void arg_dstr_set(arg_dstr_t ds, char* str, arg_dstr_freefn* free_proc);
-ARG_EXTERN void arg_dstr_cat(arg_dstr_t ds, char* str);
+ARG_EXTERN void arg_dstr_cat(arg_dstr_t ds, const char* str);
 ARG_EXTERN void arg_dstr_catf(arg_dstr_t ds, const char* fmt, ...);
 ARG_EXTERN char* arg_dstr_cstr(arg_dstr_t ds);
 

--- a/src/argtable3_private.h
+++ b/src/argtable3_private.h
@@ -95,8 +95,8 @@ typedef struct arg_hashtable {
     unsigned int entrycount;
     unsigned int loadlimit;
     unsigned int primeindex;
-    unsigned int (*hashfn)(void* k);
-    int (*eqfn)(void* k1, void* k2);
+    unsigned int (*hashfn)(const void* k);
+    int (*eqfn)(const void* k1, const void* k2);
 } arg_hashtable_t;
 
 /**
@@ -107,7 +107,7 @@ typedef struct arg_hashtable {
  * @param   eqfn      function for determining key equality
  * @return            newly created hash table or NULL on failure
  */
-arg_hashtable_t* arg_hashtable_create(unsigned int minsize, unsigned int (*hashfn)(void*), int (*eqfn)(void*, void*));
+arg_hashtable_t* arg_hashtable_create(unsigned int minsize, unsigned int (*hashfn)(const void*), int (*eqfn)(const void*, const void*));
 
 /**
  * @brief This function will cause the table to expand if the insertion would take
@@ -136,7 +136,7 @@ void arg_hashtable_insert(arg_hashtable_t* h, void* k, void* v);
  * @param   k   the key to search for  - does not claim ownership
  * @return      the value associated with the key, or NULL if none found
  */
-void* arg_hashtable_search(arg_hashtable_t* h, void* k);
+void* arg_hashtable_search(arg_hashtable_t* h, const void* k);
 
 #define ARG_DEFINE_HASHTABLE_SEARCH(fnname, keytype, valuetype) \
     valuetype* fnname(arg_hashtable_t* h, keytype* k) { return (valuetype*)(arg_hashtable_search(h, k)); }
@@ -147,7 +147,7 @@ void* arg_hashtable_search(arg_hashtable_t* h, void* k);
  * @param   h   the hash table to remove the item from
  * @param   k   the key to search for  - does not claim ownership
  */
-void arg_hashtable_remove(arg_hashtable_t* h, void* k);
+void arg_hashtable_remove(arg_hashtable_t* h, const void* k);
 
 #define ARG_DEFINE_HASHTABLE_REMOVE(fnname, keytype, valuetype) \
     valuetype* fnname(arg_hashtable_t* h, keytype* k) { return (valuetype*)(arg_hashtable_remove(h, k)); }


### PR DESCRIPTION
Is argtable3 really ANSI-C compatible?

I have some projects where there are some stringent `CFLAGS` `'-std=c89 -pedantic'` on them. When including argtable into that project it reported several errors in the library. This patch adds those `CFLAGS` and adjusts the code to make it really ANSI-C compatible.