### PR TITLE
Added a new function arg_dstr_catc() for appending char types

### DIFF
--- a/src/arg_dstr.c
+++ b/src/arg_dstr.c
@@ -177,6 +177,11 @@ void arg_dstr_cat(arg_dstr_t ds, const char* str) {
     strncat(ds->data, str, strlen(str));
 }
 
+void arg_dstr_catc(arg_dstr_t ds, char c) {
+    setup_append_buf(ds, 2);
+    strncat(ds->data, &c, 1);
+}
+
 /*
  * The logic of the `arg_dstr_catf` function is adapted from the `bformat`
  * function in The Better String Library by Paul Hsieh. Here is the copyright

--- a/src/argtable3.c
+++ b/src/argtable3.c
@@ -917,7 +917,7 @@ static void arg_print_formatted_ds(arg_dstr_t ds, const unsigned lmargin, const 
         /* Output line of text */
         while (line_start < line_end) {
             char c = *(text + line_start);
-            arg_dstr_cat(ds, &c);
+            arg_dstr_catc(ds, c);
             line_start++;
         }
         arg_dstr_cat(ds, "\n");

--- a/src/argtable3.c
+++ b/src/argtable3.c
@@ -901,8 +901,7 @@ static void arg_print_formatted_ds(arg_dstr_t ds, const unsigned lmargin, const 
         }
 
         /* Find last whitespace, that fits into line */
-        if (line_end - line_start > colwidth)
-        {
+        if (line_end - line_start > colwidth) {
             line_end = line_start + colwidth;
 
             while ((line_end > line_start) && !isspace(*(text + line_end))) {

--- a/src/argtable3.h
+++ b/src/argtable3.h
@@ -243,6 +243,7 @@ ARG_EXTERN void arg_dstr_reset(arg_dstr_t ds);
 ARG_EXTERN void arg_dstr_free(arg_dstr_t ds);
 ARG_EXTERN void arg_dstr_set(arg_dstr_t ds, char* str, arg_dstr_freefn* free_proc);
 ARG_EXTERN void arg_dstr_cat(arg_dstr_t ds, const char* str);
+ARG_EXTERN void arg_dstr_catc(arg_dstr_t ds, char c);
 ARG_EXTERN void arg_dstr_catf(arg_dstr_t ds, const char* fmt, ...);
 ARG_EXTERN char* arg_dstr_cstr(arg_dstr_t ds);
 


### PR DESCRIPTION
The arg_dstr_cat() function expects a string. When the function is passed a pointer to char type, the '\0' is missing and produces garbage.