### PR TITLE
Fix the reset function in arg_str

### DIFF
--- a/src/arg_str.c
+++ b/src/arg_str.c
@@ -39,8 +39,12 @@
 #include <stdlib.h>
 
 static void arg_str_resetfn(struct arg_str* parent) {
+    int i;
     ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
     parent->count = 0;
+    for (i = 0; i < parent->count; i++) {
+        parent->sval[i] = "";
+    }
 }
 
 static int arg_str_scanfn(struct arg_str* parent, const char* argval) {


### PR DESCRIPTION
arg_parse calls arg_reset to reset data from previous args, but arg_str_resetfn does not clear the string so it causes a parsing issue. 
an example can be found in https://github.com/oopsmonk/iota_esp32_wallet/issues/9