### PR TITLE
Rename a few generic names to unique names

### DIFF
--- a/src/argtable3_private.h
+++ b/src/argtable3_private.h
@@ -76,6 +76,17 @@ typedef void(arg_panicfn)(const char* fmt, ...);
     } while (0)
 #endif
 
+/*
+ * Rename a few generic names to unique names.
+ * They can be a problem for the platforms like NuttX, where
+ * the namespace is flat for everything including apps and libraries.
+ */
+
+#define	xmalloc	    argtable3_xmalloc
+#define	xcalloc	    argtable3_xcalloc
+#define	xrealloc	argtable3_xrealloc
+#define	xfree	    argtable3_xfree
+
 extern void dbg_printf(const char* fmt, ...);
 extern void arg_set_panic(arg_panicfn* proc);
 extern void* xmalloc(size_t size);


### PR DESCRIPTION
They can be a problem for the platforms like NuttX, where
the namespace is flat for everything including apps and libraries.