### PR TITLE
Minor clang-tidy fixes

### DIFF
--- a/src/argtable3.c
+++ b/src/argtable3.c
@@ -663,9 +663,9 @@ void arg_print_option(FILE* fp, const char* shortopts, const char* longopts, con
  */
 static void arg_print_gnuswitch_ds(arg_dstr_t ds, struct arg_hdr** table) {
     int tabindex;
-    char* format1 = " -%c";
-    char* format2 = " [-%c";
-    char* suffix = "";
+    const char* format1 = " -%c";
+    const char* format2 = " [-%c";
+    const char* suffix = "";
 
     /* print all mandatory switches that are without argument values */
     for (tabindex = 0; table[tabindex] && !(table[tabindex]->flag & ARG_TERMINATOR); tabindex++) {

--- a/src/argtable3.h
+++ b/src/argtable3.h
@@ -210,7 +210,7 @@ ARG_EXTERN struct arg_date* arg_date0(const char* shortopts, const char* longopt
 ARG_EXTERN struct arg_date* arg_date1(const char* shortopts, const char* longopts, const char* format, const char* datatype, const char* glossary);
 ARG_EXTERN struct arg_date* arg_daten(const char* shortopts, const char* longopts, const char* format, const char* datatype, int mincount, int maxcount, const char* glossary);
 
-ARG_EXTERN struct arg_end* arg_end(int maxerrors);
+ARG_EXTERN struct arg_end* arg_end(int maxcount);
 
 #define ARG_DSTR_STATIC ((arg_dstr_freefn*)0)
 #define ARG_DSTR_VOLATILE ((arg_dstr_freefn*)1)


### PR DESCRIPTION
Hi @tomghuang, thank you for maintaining this excellent library!

This small PR fixes two issues reported in [esp-idf](https://github.com/espressif/esp-idf) project by clang-tidy:

1. String literals were assigned to `char*` variables instead of `const char*`. The fix looks pretty straightforward.
2. Function argument name in declaration and definition of `arg_end` function was different (`maxerrors` vs `maxcount`). I opted to change the name in the header file for smaller number of changes. Let me know if you prefer it the other way around.