### PR TITLE
added two features to arg_print_formatted_ds

### DIFF
--- a/src/argtable3.c
+++ b/src/argtable3.c
@@ -572,7 +572,8 @@ static void arg_cat_option(char* dest, size_t ndest, const char* shortopts, cons
     }
 }
 
-static void arg_cat_optionv(char* dest, size_t ndest, const char* shortopts, const char* longopts, const char* datatype, int optvalue, const char* separator) {
+static void
+arg_cat_optionv(char* dest, size_t ndest, const char* shortopts, const char* longopts, const char* datatype, int optvalue, const char* separator) {
     separator = separator ? separator : "";
 
     if (shortopts) {
@@ -906,8 +907,8 @@ static void arg_print_formatted_ds(arg_dstr_t ds, const unsigned lmargin, const 
     while (line_end > line_start) {
         /* Eat leading white spaces. This is essential because while
            wrapping lines, there will often be a whitespace at beginning
-           of line */
-        while (isspace((int)(*(text + line_start)))) {
+           of line. Preserve newlines */
+        while (isspace((int)(*(text + line_start))) && *(text + line_start) != '\n') {
             line_start++;
         }
 
@@ -919,18 +920,31 @@ static void arg_print_formatted_ds(arg_dstr_t ds, const unsigned lmargin, const 
                 line_end--;
             }
 
-            /* Consume trailing spaces */
-            while ((line_end > line_start) && isspace((int)(*(text + line_end)))) {
-                line_end--;
-            }
+            /* If no whitespace could be found, eg. the text is one long word, break the word */
+            if (line_end == line_start) {
+                /* Set line_end to previous value */
+                line_end = line_start + colwidth;
+            } else {
+                /* Consume trailing spaces, except newlines */
+                while ((line_end > line_start) && isspace((int)(*(text + line_end))) && *(text + line_start) != '\n') {
+                    line_end--;
+                }
 
-            /* Restore the last non-space character */
-            line_end++;
+                /* Restore the last non-space character */
+                line_end++;
+            }
         }
 
         /* Output line of text */
         while (line_start < line_end) {
             char c = *(text + line_start);
+
+            /* If character is newline stop printing, skip this character, as a newline will be printed below. */
+            if (c == '\n') {
+                line_start++;
+                break;
+            }
+
             arg_dstr_catc(ds, c);
             line_start++;
         }


### PR DESCRIPTION
resolves [https://github.com/argtable/argtable3/issues/76](https://github.com/argtable/argtable3/issues/76
)
1. If newline found in text, it is printed and column count is reset.

  Previously line wrap would not take newlines found in text into account. Resulting in line wrap feature working incorrectly.
  
  Example:
    text: "a b\n c d"
    line width: 6
  
    previously:
	  "a b"
	  "c"	  <- c in new line because of \n in text
	  "d"     <- d in new line because column count reached 6 at "c"
		     and line wrap inserted newline
  
    now:
	  "a b"
	  "c d"	<- "c d" in new line because of \n in text,
		     line wrap does not insert newline between c and d

2. If a very long word is in text, it is broken up differently than before. Previously the long word was printed one character per line. Now as much characters of the long word as can fit in a line are printed.
  
  Example:
    text: "test"
    line width: 3
  
    previously:
	  t
	  e
	  s
	  t
  
    now:
	  tes
	  t