### PR TITLE
stack corruption for long cmdline args

### DIFF
--- a/src/argtable3.c
+++ b/src/argtable3.c
@@ -504,11 +504,11 @@ static void arg_cat(char** pdest, const char* src, size_t* pndest) {
     char* end = dest + *pndest;
 
     /*locate null terminator of dest string */
-    while (dest < end && *dest != 0)
+    while (dest < end-1 && *dest != 0)
         dest++;
 
     /* concat src string to dest string */
-    while (dest < end && *src != 0)
+    while (dest < end-1 && *src != 0)
         *dest++ = *src++;
 
     /* null terminate dest string */


### PR DESCRIPTION
see: https://github.com/espressif/esp-idf/pull/10016