### PR TITLE
Improve flexibility of argtable3 configuration options

### DIFF
--- a/src/arg_getopt_long.c
+++ b/src/arg_getopt_long.c
@@ -50,6 +50,9 @@
  */
 
 #include "argtable3.h"
+#ifndef ARG_AMALGAMATION
+#include "argtable3_private.h"
+#endif
 
 #if ARG_REPLACE_GETOPT == 1
 

--- a/src/argtable3.h
+++ b/src/argtable3.h
@@ -41,13 +41,16 @@ extern "C" {
 #endif
 
 #define ARG_REX_ICASE 1
-#define ARG_DSTR_SIZE 200
-#define ARG_CMD_NAME_LEN 100
-#define ARG_CMD_DESCRIPTION_LEN 256
 
-#ifndef ARG_REPLACE_GETOPT
-#define ARG_REPLACE_GETOPT 1 /* use the embedded getopt as the system getopt(3) */
-#endif /* ARG_REPLACE_GETOPT */
+/* Maximum length of the command name */
+#ifndef ARG_CMD_NAME_LEN
+#define ARG_CMD_NAME_LEN 100
+#endif /* ARG_CMD_NAME_LEN */
+
+/* Maximum length of the command description */
+#ifndef ARG_CMD_DESCRIPTION_LEN
+#define ARG_CMD_DESCRIPTION_LEN 256
+#endif /* ARG_CMD_DESCRIPTION_LEN */
 
 /* bit masks for arg_hdr.flag */
 enum { ARG_TERMINATOR = 0x1, ARG_HASVALUE = 0x2, ARG_HASOPTVALUE = 0x4 };

--- a/src/argtable3_private.h
+++ b/src/argtable3_private.h
@@ -35,8 +35,13 @@
 
 #include <stdlib.h>
 
+#ifndef ARG_ENABLE_TRACE
 #define ARG_ENABLE_TRACE 0
+#endif /* ARG_ENABLE_TRACE */
+
+#ifndef ARG_ENABLE_LOG
 #define ARG_ENABLE_LOG 1
+#endif /* ARG_ENABLE_LOG */
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/argtable3_private.h
+++ b/src/argtable3_private.h
@@ -43,6 +43,18 @@
 #define ARG_ENABLE_LOG 1
 #endif /* ARG_ENABLE_LOG */
 
+/* Use the embedded getopt as the system getopt(3) */
+#ifndef ARG_REPLACE_GETOPT
+#define ARG_REPLACE_GETOPT 1
+#endif /* ARG_REPLACE_GETOPT */
+
+/* Size of the buffer pre-allocated for dynamic strings.
+ * If the length exceeds this size, the buffer will be dynamically allocated.
+ */
+#ifndef ARG_DSTR_SIZE
+#define ARG_DSTR_SIZE 200
+#endif /* ARG_DSTR_SIZE */
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
This PR aims to improve the flexibility of argtable3 configuration options. With these changes, including argtable3 into other projects becomes easier, since the source code of argtable3 no longer has to be modified. This allows, for example, using the original source files from Github Releases of argtable3, instead of vendoring the argtable3 source code into the project.

* feat: Make ARG_ENABLE_TRACE and ARG_ENABLE_LOG configurable
   
   Currently to configure ARG_ENABLE_TRACE or ARG_ENABLE_LOG, we have to modify argtable3 source code. This commit allows setting these options via the compiler flags.

* feat: make configuration options from argtable3.h configurable

   Currently several argtable3 options can be modified only by changing them in source code. This commit makes these options configurable by adding ifndef guards: `ARG_DSTR_SIZE`, `ARG_CMD_NAME_LEN`, `ARG_CMD_DESCRIPTION_LEN`.

   Additionally, `ARG_DSTR_SIZE` and `ARG_REPLACE_GETOPT` options are moved to argtable_private.h. This is done for two reasons:

   - Having them in argtable_private.h allows defining compiler flags (such as `-DARG_DSTR_SIZE=100`) for argtable3 files only. If the definitions are in the public header file (argtable3.h) then technically we have to pass `-DARG_DSTR_SIZE=100` also to other files in the project, so that they evaluate argtable3.h in the same way.

   - Having them in argtable3.h is actually not necessary, since they are not used anywhere in the public interface.

## Testing

I have checked that `make && make test` still pass after these changes.