### PR TITLE
feat: re-introduce `arg_print_formatted`

### DIFF
--- a/src/argtable3.c
+++ b/src/argtable3.c
@@ -864,31 +864,7 @@ void arg_print_glossary(FILE* fp, void** argtable, const char* format) {
  * to right margin. The function does not indent the first line, but
  * only the following ones.
  *
- * Example:
- * arg_print_formatted( fp, 0, 5, "Some text that doesn't fit." )
- * will result in the following output:
- *
- * Some
- * text
- * that
- * doesn'
- * t fit.
- *
- * Too long lines will be wrapped in the middle of a word.
- *
- * arg_print_formatted( fp, 2, 7, "Some text that doesn't fit." )
- * will result in the following output:
- *
- * Some
- *   text
- *   that
- *   doesn'
- *   t fit.
- *
- * As you see, the first line is not indented. This enables output of
- * lines, which start in a line where output already happened.
- *
- * Author: Uli Fouquet
+ * See description of arg_print_formatted below.
  */
 static void arg_print_formatted_ds(arg_dstr_t ds, const unsigned lmargin, const unsigned rmargin, const char* text) {
     const unsigned int textlen = (unsigned int)strlen(text);
@@ -960,6 +936,45 @@ static void arg_print_formatted_ds(arg_dstr_t ds, const unsigned lmargin, const 
             line_end = textlen;
         }
     } /* lines of text */
+}
+
+/**
+ * Print a piece of text formatted, which means in a column with a
+ * left and a right margin. The lines are wrapped at whitspaces next
+ * to right margin. The function does not indent the first line, but
+ * only the following ones.
+ *
+ * Example:
+ * arg_print_formatted( fp, 0, 5, "Some text that doesn't fit." )
+ * will result in the following output:
+ *
+ * Some
+ * text
+ * that
+ * doesn'
+ * t fit.
+ *
+ * Too long lines will be wrapped in the middle of a word.
+ *
+ * arg_print_formatted( fp, 2, 7, "Some text that doesn't fit." )
+ * will result in the following output:
+ *
+ * Some
+ *   text
+ *   that
+ *   doesn'
+ *   t fit.
+ *
+ * As you see, the first line is not indented. This enables output of
+ * lines, which start in a line where output already happened.
+ *
+ * Author: Uli Fouquet
+ */
+void arg_print_formatted(FILE* fp, const unsigned lmargin, const unsigned rmargin, const char* text) {
+    arg_dstr_t ds = arg_dstr_create();
+    arg_print_formatted_ds(ds, lmargin, rmargin, text);
+    fputs(arg_dstr_cstr(ds), fp);
+    arg_dstr_destroy(ds);
 }
 
 /**

--- a/src/argtable3.h
+++ b/src/argtable3.h
@@ -231,6 +231,7 @@ ARG_EXTERN void arg_print_syntaxv_ds(arg_dstr_t ds, void** argtable, const char*
 ARG_EXTERN void arg_print_glossary_ds(arg_dstr_t ds, void** argtable, const char* format);
 ARG_EXTERN void arg_print_glossary_gnu_ds(arg_dstr_t ds, void** argtable);
 ARG_EXTERN void arg_print_errors_ds(arg_dstr_t ds, struct arg_end* end, const char* progname);
+ARG_EXTERN void arg_print_formatted(FILE *fp, const unsigned lmargin, const unsigned rmargin, const char *text);
 ARG_EXTERN void arg_freetable(void** argtable, size_t n);
 
 ARG_EXTERN arg_dstr_t arg_dstr_create(void);


### PR DESCRIPTION
`arg_print_formatted` was made non-static in 61743612fb, but then was lost in 358498b376f.

This PR makes this function available again.