### PR TITLE
ci: run clang-tidy and generate Github code scanning report

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,1 @@
+Checks: "-bugprone-*,clang-diagnostic-*,clang-analyzer-*,-modernize-*,-performance-*,-readability-*"

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,41 @@
+name: Run clang-tidy
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Run clang-tidy
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run CMake to generate the compilation database
+        run: |
+          mkdir build
+          cmake -B build -DARGTABLE3_ENABLE_TESTS=0 -DARGTABLE3_ENABLE_EXAMPLES=0 -DCMAKE_EXPORT_COMPILE_COMMANDS=1 .
+      - name: Run clang-tidy on files in src/
+        run: |
+          clang-tidy -p build/compile_commands.json src/*.c | tee warnings.txt
+      - name: Convert absolute paths to relative ones
+        run: |
+          sed -i "s|${GITHUB_WORKSPACE}/||g" warnings.txt
+      - name: Download clang-tidy-sarif
+        run: |
+          curl -sSL https://github.com/psastras/sarif-rs/releases/download/clang-tidy-sarif-v0.3.3/clang-tidy-sarif-x86_64-unknown-linux-gnu -o clang-tidy-sarif
+          chmod +x clang-tidy-sarif
+      - name: Convert clang-tidy warnings to SARIF
+        run: |
+          ./clang-tidy-sarif -o results.sarif warnings.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          path: |
+            warnings.txt
+            results.sarif
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: results.sarif
+          category: clang-tidy


### PR DESCRIPTION
Related to https://github.com/argtable/argtable3/issues/70

This PR adds a Github Actions job which:
- runs clang-tidy 
- generates a report in SARIF format, compatible with Github [Code Scanning Alerts](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/about-code-scanning-alerts).

Clang-tidy is currently run with a minimal set of checks, which produces around 9 warnings in this repository. If we enable all the `bugprone-*` checks, that will be several hundred more, so some cleanup is necessary if we want to enable those. The config is located in `.clang-tidy` file.

The alerts for the existing code will appear at https://github.com/argtable/argtable3/security/code-scanning. That page is visible **only** to repository collaborators with `Write` and higher levels of access. (Not sure why Github has such a limit; anyone can fork a repository and then see the alerts reported in their fork!)

If a pull request introduces a new alert, it will be shown in the PR as a note.

Example run of this workflow in my fork: https://github.com/igrr/argtable3/actions/runs/3371072231.

<details> <summary> Example screenshots: </summary>

## Summary of alerts:

<img width="945" alt="Screenshot 2022-11-01 at 17 19 11" src="https://user-images.githubusercontent.com/4349050/199284042-e749020e-81a0-4302-a6db-0f42440f5f3c.png">

## Details of one alert:

<img width="1077" alt="Screenshot 2022-11-01 at 17 19 37" src="https://user-images.githubusercontent.com/4349050/199284064-ad001fca-066b-4e05-8241-826fb7677f07.png">

</details>