### PR TITLE
Update CMakeLists.txt to fix CMAKE_CURRENT_SOURCE_DIR

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,7 +78,7 @@ endif()
 
 add_library(${ARGTABLE3_PROJECT_NAME}::argtable3 ALIAS argtable3)
 target_include_directories(argtable3 PUBLIC
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCEDIR}>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 


### PR DESCRIPTION
Changes CMAKE_CURRENT_SOURCEDIR to CMAKE_CURRENT_SOURCE_DIR.
Fixes #86 