### PR TITLE
Add ClusterFuzzLite integration

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,8 +1,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool cmake \
-                      pkg-config curl check
+RUN apt-get update && apt-get install -y make autoconf automake libtool cmake
 COPY . $SRC/argtable3
 COPY .clusterfuzzlite/build.sh $SRC/build.sh
-COPY .clusterfuzzlite/*.cpp $SRC/
 COPY .clusterfuzzlite/*.c $SRC/
 WORKDIR argtable3

--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,8 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool cmake \
+                      pkg-config curl check
+COPY . $SRC/argtable3
+COPY .clusterfuzzlite/build.sh $SRC/build.sh
+COPY .clusterfuzzlite/*.cpp $SRC/
+COPY .clusterfuzzlite/*.c $SRC/
+WORKDIR argtable3

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 mkdir fuzz-build
 cd fuzz-build
-cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_CXX_FLAGS="$CXXFLAGS" ../
-sed -i 's/SHARED/STATIC/g' ../CMakeLists.txt
-make V=1 || true
+cmake -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_CXX_FLAGS="$CXXFLAGS" ../
+make
 
-$CC $CFLAGS $LIB_FUZZING_ENGINE $SRC/fuzzer.c -Wl,--whole-archive $SRC/argtable3/fuzz-build$SRC/libargtable3_static.a -Wl,--allow-multiple-definition -I$SRC/argtable3/dist/tests -I$SRC/argtable3/tests -I$SRC/argtable3/src -I$SRC/argtable3/dist  -o $OUT/fuzzer
+$CC $CFLAGS $LIB_FUZZING_ENGINE $SRC/fuzzer.c \
+  -Wl,--whole-archive $SRC/argtable3/fuzz-build$SRC/libargtable3_static.a \
+  -Wl,--allow-multiple-definition \
+  -I$SRC/argtable3/src \
+  -o $OUT/fuzzer

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+mkdir fuzz-build
+cd fuzz-build
+cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_CXX_FLAGS="$CXXFLAGS" ../
+sed -i 's/SHARED/STATIC/g' ../CMakeLists.txt
+make V=1 || true
+
+$CC $CFLAGS $LIB_FUZZING_ENGINE $SRC/fuzzer.c -Wl,--whole-archive $SRC/argtable3/fuzz-build$SRC/libargtable3_static.a -Wl,--allow-multiple-definition -I$SRC/argtable3/dist/tests -I$SRC/argtable3/tests -I$SRC/argtable3/src -I$SRC/argtable3/dist  -o $OUT/fuzzer

--- a/.clusterfuzzlite/fuzzer.c
+++ b/.clusterfuzzlite/fuzzer.c
@@ -1,0 +1,33 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "argtable3.h"
+#include "argtable3_private.h"
+#include "CuTest.h"
+#include "arg_getopt.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size < 3) {
+        return 0;
+    }
+
+    // Prepare input data
+    const char *input1 = (const char*)data;
+    const char *input2 = (const char*)(data + 1);
+    struct tm tm_value;
+
+    // Ensure null-terminated strings
+    char str1[size+1];
+    char str2[size];
+    memcpy(str1, input1, size);
+    str1[size] = '\0';
+    memcpy(str2, input2, size-1);
+    str2[size-1] = '\0';
+
+    // Call the target function
+    arg_strptime(str1, str2, &tm_value);
+
+    return 0;
+}

--- a/.clusterfuzzlite/fuzzer.c
+++ b/.clusterfuzzlite/fuzzer.c
@@ -1,12 +1,7 @@
-#include <stdlib.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
 
 #include "argtable3.h"
-#include "argtable3_private.h"
-#include "CuTest.h"
-#include "arg_getopt.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     if (size < 3) {

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: c

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,30 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ master ]
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: c++
+        bad-build-check: false
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 100
+        mode: 'code-change'
+        report-unreproducible-crashes: false
+        sanitizer: ${{ matrix.sanitizer }}


### PR DESCRIPTION
This adds fuzzing by way of [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/), which is a GitHub action that will perform a short amount of fuzzing for new PRs. The goal is to use fuzzing to catch bugs that may be introduced by new PRs.

If you'd like to test this the way ClusterFuzzLite runs it (by way of OSS-Fuzz) you can use the steps:

```sh
git clone https://github.com/google/oss-fuzz
git clone https://github.com/DavidKorczynski/argtable3
cd argtable3
git checkout cflite

# Build the fuzzers in .clusterfuzzlite
python3 ../oss-fuzz/infra/helper.py build_fuzzers --external $PWD

# Run the fuzzer for 10 seconds
python3 ../oss-fuzz/infra/helper.py run_fuzzer --external $PWD fuzzer -- -max_total_time=10
```