### PR TITLE
Make argtable3 able to build for Playstation Portable

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,7 +93,7 @@ set_target_properties(argtable3 PROPERTIES
 )
 
 include(GNUInstallDirs)
-if(UNIX OR MSYS OR MINGW)
+if(UNIX OR MSYS OR MINGW OR PSP)
   set(ARGTABLE3_INSTALL_CMAKEDIR ${CMAKE_INSTALL_LIBDIR}/cmake/argtable3)
 elseif(WIN32)
   set(ARGTABLE3_INSTALL_CMAKEDIR "cmake")


### PR DESCRIPTION
Hello, I'm one of the maintainers of an homebrew development kit for the Playstation Portable and to be able to build argtable3 for our platform this seems to be the only required change. It would be cool to have this upstream.