### PR TITLE
Fix undefined behavior in callback functions' parameter passing

### DIFF
--- a/src/arg_date.c
+++ b/src/arg_date.c
@@ -41,12 +41,14 @@
 
 char* arg_strptime(const char* buf, const char* fmt, struct tm* tm);
 
-static void arg_date_resetfn(struct arg_date* parent) {
+static void arg_date_resetfn(void* parent_) {
+    struct arg_date* parent = parent_;
     ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
     parent->count = 0;
 }
 
-static int arg_date_scanfn(struct arg_date* parent, const char* argval) {
+static int arg_date_scanfn(void* parent_, const char* argval) {
+    struct arg_date* parent = parent_;
     int errorcode = 0;
 
     if (parent->count == parent->hdr.maxcount) {
@@ -70,14 +72,16 @@ static int arg_date_scanfn(struct arg_date* parent, const char* argval) {
     return errorcode;
 }
 
-static int arg_date_checkfn(struct arg_date* parent) {
+static int arg_date_checkfn(void* parent_) {
+    struct arg_date* parent = parent_;
     int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
 
     ARG_TRACE(("%s:checkfn(%p) returns %d\n", __FILE__, parent, errorcode));
     return errorcode;
 }
 
-static void arg_date_errorfn(struct arg_date* parent, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
+static void arg_date_errorfn(void* parent_, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
+    struct arg_date* parent = parent_;
     const char* shortopts = parent->hdr.shortopts;
     const char* longopts = parent->hdr.longopts;
     const char* datatype = parent->hdr.datatype;
@@ -147,10 +151,10 @@ arg_daten(const char* shortopts, const char* longopts, const char* format, const
     result->hdr.mincount = mincount;
     result->hdr.maxcount = maxcount;
     result->hdr.parent = result;
-    result->hdr.resetfn = (arg_resetfn*)arg_date_resetfn;
-    result->hdr.scanfn = (arg_scanfn*)arg_date_scanfn;
-    result->hdr.checkfn = (arg_checkfn*)arg_date_checkfn;
-    result->hdr.errorfn = (arg_errorfn*)arg_date_errorfn;
+    result->hdr.resetfn = arg_date_resetfn;
+    result->hdr.scanfn = arg_date_scanfn;
+    result->hdr.checkfn = arg_date_checkfn;
+    result->hdr.errorfn = arg_date_errorfn;
 
     /* store the tmval[maxcount] array immediately after the arg_date struct */
     result->tmval = (struct tm*)(result + 1);

--- a/src/arg_dbl.c
+++ b/src/arg_dbl.c
@@ -38,12 +38,14 @@
 
 #include <stdlib.h>
 
-static void arg_dbl_resetfn(struct arg_dbl* parent) {
+static void arg_dbl_resetfn(void* parent_) {
+    struct arg_dbl* parent = parent_;
     ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
     parent->count = 0;
 }
 
-static int arg_dbl_scanfn(struct arg_dbl* parent, const char* argval) {
+static int arg_dbl_scanfn(void* parent_, const char* argval) {
+    struct arg_dbl* parent = parent_;
     int errorcode = 0;
 
     if (parent->count == parent->hdr.maxcount) {
@@ -72,14 +74,16 @@ static int arg_dbl_scanfn(struct arg_dbl* parent, const char* argval) {
     return errorcode;
 }
 
-static int arg_dbl_checkfn(struct arg_dbl* parent) {
+static int arg_dbl_checkfn(void* parent_) {
+    struct arg_dbl* parent = parent_;
     int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
 
     ARG_TRACE(("%s:checkfn(%p) returns %d\n", __FILE__, parent, errorcode));
     return errorcode;
 }
 
-static void arg_dbl_errorfn(struct arg_dbl* parent, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
+static void arg_dbl_errorfn(void* parent_, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
+    struct arg_dbl* parent = parent_;
     const char* shortopts = parent->hdr.shortopts;
     const char* longopts = parent->hdr.longopts;
     const char* datatype = parent->hdr.datatype;
@@ -137,10 +141,10 @@ struct arg_dbl* arg_dbln(const char* shortopts, const char* longopts, const char
     result->hdr.mincount = mincount;
     result->hdr.maxcount = maxcount;
     result->hdr.parent = result;
-    result->hdr.resetfn = (arg_resetfn*)arg_dbl_resetfn;
-    result->hdr.scanfn = (arg_scanfn*)arg_dbl_scanfn;
-    result->hdr.checkfn = (arg_checkfn*)arg_dbl_checkfn;
-    result->hdr.errorfn = (arg_errorfn*)arg_dbl_errorfn;
+    result->hdr.resetfn = arg_dbl_resetfn;
+    result->hdr.scanfn = arg_dbl_scanfn;
+    result->hdr.checkfn = arg_dbl_checkfn;
+    result->hdr.errorfn = arg_dbl_errorfn;
 
     /* Store the dval[maxcount] array on the first double boundary that
      * immediately follows the arg_dbl struct. We do the memory alignment

--- a/src/arg_end.c
+++ b/src/arg_end.c
@@ -38,7 +38,8 @@
 
 #include <stdlib.h>
 
-static void arg_end_resetfn(struct arg_end* parent) {
+static void arg_end_resetfn(void* parent_) {
+    struct arg_end* parent = parent_;
     ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
     parent->count = 0;
 }
@@ -94,10 +95,10 @@ struct arg_end* arg_end(int maxcount) {
     result->hdr.mincount = 1;
     result->hdr.maxcount = maxcount;
     result->hdr.parent = result;
-    result->hdr.resetfn = (arg_resetfn*)arg_end_resetfn;
+    result->hdr.resetfn = arg_end_resetfn;
     result->hdr.scanfn = NULL;
     result->hdr.checkfn = NULL;
-    result->hdr.errorfn = (arg_errorfn*)arg_end_errorfn;
+    result->hdr.errorfn = arg_end_errorfn;
 
     /* store error[maxcount] array immediately after struct arg_end */
     result->error = (int*)(result + 1);

--- a/src/arg_file.c
+++ b/src/arg_file.c
@@ -47,7 +47,8 @@
 #define FILESEPARATOR2 '/'
 #endif
 
-static void arg_file_resetfn(struct arg_file* parent) {
+static void arg_file_resetfn(void* parent_) {
+    struct arg_file* parent = parent_;
     ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
     parent->count = 0;
 }
@@ -98,7 +99,8 @@ static const char* arg_extension(const char* basename) {
     return result;
 }
 
-static int arg_file_scanfn(struct arg_file* parent, const char* argval) {
+static int arg_file_scanfn(void* parent_, const char* argval) {
+    struct arg_file* parent = parent_;
     int errorcode = 0;
 
     if (parent->count == parent->hdr.maxcount) {
@@ -121,14 +123,16 @@ static int arg_file_scanfn(struct arg_file* parent, const char* argval) {
     return errorcode;
 }
 
-static int arg_file_checkfn(struct arg_file* parent) {
+static int arg_file_checkfn(void* parent_) {
+    struct arg_file* parent = parent_;
     int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
 
     ARG_TRACE(("%s:checkfn(%p) returns %d\n", __FILE__, parent, errorcode));
     return errorcode;
 }
 
-static void arg_file_errorfn(struct arg_file* parent, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
+static void arg_file_errorfn(void* parent_, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
+    struct arg_file* parent = parent_;
     const char* shortopts = parent->hdr.shortopts;
     const char* longopts = parent->hdr.longopts;
     const char* datatype = parent->hdr.datatype;
@@ -185,10 +189,10 @@ struct arg_file* arg_filen(const char* shortopts, const char* longopts, const ch
     result->hdr.mincount = mincount;
     result->hdr.maxcount = maxcount;
     result->hdr.parent = result;
-    result->hdr.resetfn = (arg_resetfn*)arg_file_resetfn;
-    result->hdr.scanfn = (arg_scanfn*)arg_file_scanfn;
-    result->hdr.checkfn = (arg_checkfn*)arg_file_checkfn;
-    result->hdr.errorfn = (arg_errorfn*)arg_file_errorfn;
+    result->hdr.resetfn = arg_file_resetfn;
+    result->hdr.scanfn = arg_file_scanfn;
+    result->hdr.checkfn = arg_file_checkfn;
+    result->hdr.errorfn = arg_file_errorfn;
 
     /* store the filename,basename,extension arrays immediately after the arg_file struct */
     result->filename = (const char**)(result + 1);

--- a/src/arg_int.c
+++ b/src/arg_int.c
@@ -40,7 +40,8 @@
 #include <limits.h>
 #include <stdlib.h>
 
-static void arg_int_resetfn(struct arg_int* parent) {
+static void arg_int_resetfn(void* parent_) {
+    struct arg_int* parent = parent_;
     ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
     parent->count = 0;
 }
@@ -136,7 +137,8 @@ static int detectsuffix(const char* str, const char* suffix) {
     return (*str == '\0') ? 1 : 0;
 }
 
-static int arg_int_scanfn(struct arg_int* parent, const char* argval) {
+static int arg_int_scanfn(void* parent_, const char* argval) {
+    struct arg_int* parent = parent_;
     int errorcode = 0;
 
     if (parent->count == parent->hdr.maxcount) {
@@ -207,13 +209,15 @@ static int arg_int_scanfn(struct arg_int* parent, const char* argval) {
     return errorcode;
 }
 
-static int arg_int_checkfn(struct arg_int* parent) {
+static int arg_int_checkfn(void* parent_) {
+    struct arg_int* parent = parent_;
     int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
     /*printf("%s:checkfn(%p) returns %d\n",__FILE__,parent,errorcode);*/
     return errorcode;
 }
 
-static void arg_int_errorfn(struct arg_int* parent, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
+static void arg_int_errorfn(void* parent_, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
+    struct arg_int* parent = parent_;
     const char* shortopts = parent->hdr.shortopts;
     const char* longopts = parent->hdr.longopts;
     const char* datatype = parent->hdr.datatype;
@@ -275,10 +279,10 @@ struct arg_int* arg_intn(const char* shortopts, const char* longopts, const char
     result->hdr.mincount = mincount;
     result->hdr.maxcount = maxcount;
     result->hdr.parent = result;
-    result->hdr.resetfn = (arg_resetfn*)arg_int_resetfn;
-    result->hdr.scanfn = (arg_scanfn*)arg_int_scanfn;
-    result->hdr.checkfn = (arg_checkfn*)arg_int_checkfn;
-    result->hdr.errorfn = (arg_errorfn*)arg_int_errorfn;
+    result->hdr.resetfn = arg_int_resetfn;
+    result->hdr.scanfn = arg_int_scanfn;
+    result->hdr.checkfn = arg_int_checkfn;
+    result->hdr.errorfn = arg_int_errorfn;
 
     /* store the ival[maxcount] array immediately after the arg_int struct */
     result->ival = (int*)(result + 1);

--- a/src/arg_lit.c
+++ b/src/arg_lit.c
@@ -38,12 +38,14 @@
 
 #include <stdlib.h>
 
-static void arg_lit_resetfn(struct arg_lit* parent) {
+static void arg_lit_resetfn(void* parent_) {
+    struct arg_lit* parent = parent_;
     ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
     parent->count = 0;
 }
 
-static int arg_lit_scanfn(struct arg_lit* parent, const char* argval) {
+static int arg_lit_scanfn(void* parent_, const char* argval) {
+    struct arg_lit* parent = parent_;
     int errorcode = 0;
     if (parent->count < parent->hdr.maxcount)
         parent->count++;
@@ -54,13 +56,15 @@ static int arg_lit_scanfn(struct arg_lit* parent, const char* argval) {
     return errorcode;
 }
 
-static int arg_lit_checkfn(struct arg_lit* parent) {
+static int arg_lit_checkfn(void* parent_) {
+    struct arg_lit* parent = parent_;
     int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
     ARG_TRACE(("%s:checkfn(%p) returns %d\n", __FILE__, parent, errorcode));
     return errorcode;
 }
 
-static void arg_lit_errorfn(struct arg_lit* parent, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
+static void arg_lit_errorfn(void* parent_, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
+    struct arg_lit* parent = parent_;
     const char* shortopts = parent->hdr.shortopts;
     const char* longopts = parent->hdr.longopts;
     const char* datatype = parent->hdr.datatype;
@@ -106,10 +110,10 @@ struct arg_lit* arg_litn(const char* shortopts, const char* longopts, int mincou
     result->hdr.mincount = mincount;
     result->hdr.maxcount = maxcount;
     result->hdr.parent = result;
-    result->hdr.resetfn = (arg_resetfn*)arg_lit_resetfn;
-    result->hdr.scanfn = (arg_scanfn*)arg_lit_scanfn;
-    result->hdr.checkfn = (arg_checkfn*)arg_lit_checkfn;
-    result->hdr.errorfn = (arg_errorfn*)arg_lit_errorfn;
+    result->hdr.resetfn = arg_lit_resetfn;
+    result->hdr.scanfn = arg_lit_scanfn;
+    result->hdr.checkfn = arg_lit_checkfn;
+    result->hdr.errorfn = arg_lit_errorfn;
 
     /* init local variables */
     result->count = 0;

--- a/src/arg_rex.c
+++ b/src/arg_rex.c
@@ -122,12 +122,14 @@ struct privhdr {
     int flags;
 };
 
-static void arg_rex_resetfn(struct arg_rex* parent) {
+static void arg_rex_resetfn(void* parent_) {
+    struct arg_rex* parent = parent_;
     ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
     parent->count = 0;
 }
 
-static int arg_rex_scanfn(struct arg_rex* parent, const char* argval) {
+static int arg_rex_scanfn(void* parent_, const char* argval) {
+    struct arg_rex* parent = parent_;
     int errorcode = 0;
     const TRexChar* error = NULL;
     TRex* rex = NULL;
@@ -161,7 +163,8 @@ static int arg_rex_scanfn(struct arg_rex* parent, const char* argval) {
     return errorcode;
 }
 
-static int arg_rex_checkfn(struct arg_rex* parent) {
+static int arg_rex_checkfn(void* parent_) {
+    struct arg_rex* parent = parent_;
     int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
 #if 0
     struct privhdr *priv = (struct privhdr*)parent->hdr.priv;
@@ -174,7 +177,8 @@ static int arg_rex_checkfn(struct arg_rex* parent) {
     return errorcode;
 }
 
-static void arg_rex_errorfn(struct arg_rex* parent, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
+static void arg_rex_errorfn(void* parent_, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
+    struct arg_rex* parent = parent_;
     const char* shortopts = parent->hdr.shortopts;
     const char* longopts = parent->hdr.longopts;
     const char* datatype = parent->hdr.datatype;
@@ -255,10 +259,10 @@ struct arg_rex* arg_rexn(const char* shortopts,
     result->hdr.mincount = mincount;
     result->hdr.maxcount = maxcount;
     result->hdr.parent = result;
-    result->hdr.resetfn = (arg_resetfn*)arg_rex_resetfn;
-    result->hdr.scanfn = (arg_scanfn*)arg_rex_scanfn;
-    result->hdr.checkfn = (arg_checkfn*)arg_rex_checkfn;
-    result->hdr.errorfn = (arg_errorfn*)arg_rex_errorfn;
+    result->hdr.resetfn = arg_rex_resetfn;
+    result->hdr.scanfn = arg_rex_scanfn;
+    result->hdr.checkfn = arg_rex_checkfn;
+    result->hdr.errorfn = arg_rex_errorfn;
 
     /* store the arg_rex_priv struct immediately after the arg_rex struct */
     result->hdr.priv = result + 1;

--- a/src/arg_str.c
+++ b/src/arg_str.c
@@ -38,7 +38,8 @@
 
 #include <stdlib.h>
 
-static void arg_str_resetfn(struct arg_str* parent) {
+static void arg_str_resetfn(void* parent_) {
+    struct arg_str* parent = parent_;
     int i;
 
     ARG_TRACE(("%s:resetfn(%p)\n", __FILE__, parent));
@@ -48,7 +49,8 @@ static void arg_str_resetfn(struct arg_str* parent) {
     parent->count = 0;
 }
 
-static int arg_str_scanfn(struct arg_str* parent, const char* argval) {
+static int arg_str_scanfn(void* parent_, const char* argval) {
+    struct arg_str* parent = parent_;
     int errorcode = 0;
 
     if (parent->count == parent->hdr.maxcount) {
@@ -67,14 +69,16 @@ static int arg_str_scanfn(struct arg_str* parent, const char* argval) {
     return errorcode;
 }
 
-static int arg_str_checkfn(struct arg_str* parent) {
+static int arg_str_checkfn(void* parent_) {
+    struct arg_str* parent = parent_;
     int errorcode = (parent->count < parent->hdr.mincount) ? ARG_ERR_MINCOUNT : 0;
 
     ARG_TRACE(("%s:checkfn(%p) returns %d\n", __FILE__, parent, errorcode));
     return errorcode;
 }
 
-static void arg_str_errorfn(struct arg_str* parent, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
+static void arg_str_errorfn(void* parent_, arg_dstr_t ds, int errorcode, const char* argval, const char* progname) {
+    struct arg_str* parent = parent_;
     const char* shortopts = parent->hdr.shortopts;
     const char* longopts = parent->hdr.longopts;
     const char* datatype = parent->hdr.datatype;
@@ -128,10 +132,10 @@ struct arg_str* arg_strn(const char* shortopts, const char* longopts, const char
     result->hdr.mincount = mincount;
     result->hdr.maxcount = maxcount;
     result->hdr.parent = result;
-    result->hdr.resetfn = (arg_resetfn*)arg_str_resetfn;
-    result->hdr.scanfn = (arg_scanfn*)arg_str_scanfn;
-    result->hdr.checkfn = (arg_checkfn*)arg_str_checkfn;
-    result->hdr.errorfn = (arg_errorfn*)arg_str_errorfn;
+    result->hdr.resetfn = arg_str_resetfn;
+    result->hdr.scanfn = arg_str_scanfn;
+    result->hdr.checkfn = arg_str_checkfn;
+    result->hdr.errorfn = arg_str_errorfn;
 
     /* store the sval[maxcount] array immediately after the arg_str struct */
     result->sval = (const char**)(result + 1);


### PR DESCRIPTION
There is undefined behavior in how the callback functions arg_resetfn, arg_scanfn, arg_checkfn, and arg_errorfn are used currently. The original type of those functions has the parent type as `void*`, but the actual function implementations have the `void*` parent as something like `struct arg_date* parent`, but they are cast to the function type with `void*` parent. This is apparently undefined behavior, and the clang undefined behavior sanitizer catches this.

So, to see the errors, use this change to CMakeLists.txt:

```
diff --git a/CMakeLists.txt b/CMakeLists.txt
index 67cee27..f267a19 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,9 @@ if(ARGTABLE3_ENABLE_CONAN AND EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-rpath-link,${LINK_FLAGS}")
 endif()
 
+add_compile_options("-fsanitize=undefined")
+add_link_options("-fsanitize=undefined")
+
 set(ARGTABLE3_AMALGAMATION_SRC_FILE ${PROJECT_SOURCE_DIR}/dist/argtable3.c)
 set(ARGTABLE3_SRC_FILES
   ${PROJECT_SOURCE_DIR}/src/arg_cmd.c
```

The errors will looks like:
```
./tests/test_amalgamation 
/home/martti/gh/argtable3/dist/argtable3.c:5374:13: runtime error: call to function arg_lit_resetfn through pointer to incorrect function type 'void (*)(void *)'
/home/martti/gh/argtable3/dist/argtable3.c:3378: note: arg_lit_resetfn defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/martti/gh/argtable3/dist/argtable3.c:5374:13 
/home/martti/gh/argtable3/dist/argtable3.c:5227:37: runtime error: call to function arg_lit_scanfn through pointer to incorrect function type 'int (*)(void *, const char *)'
/home/martti/gh/argtable3/dist/argtable3.c:3383: note: arg_lit_scanfn defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/martti/gh/argtable3/dist/argtable3.c:5227:37 
/home/martti/gh/argtable3/dist/argtable3.c:5361:29: runtime error: call to function arg_lit_checkfn through pointer to incorrect function type 'int (*)(void *)'
/home/martti/gh/argtable3/dist/argtable3.c:3394: note: arg_lit_checkfn defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/martti/gh/argtable3/dist/argtable3.c:5361:29 
/home/martti/gh/argtable3/dist/argtable3.c:5270:41: runtime error: call to function arg_lit_scanfn through pointer to incorrect function type 'int (*)(void *, const char *)'
/home/martti/gh/argtable3/dist/argtable3.c:3383: note: arg_lit_scanfn defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/martti/gh/argtable3/dist/argtable3.c:5270:41 
/home/martti/gh/argtable3/dist/argtable3.c:5319:21: runtime error: call to function arg_int_scanfn through pointer to incorrect function type 'int (*)(void *, const char *)'
/home/martti/gh/argtable3/dist/argtable3.c:3187: note: arg_int_scanfn defined here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/martti/gh/argtable3/dist/argtable3.c:5319:21 
```
