### PR TITLE
build: add coverity scan in ci

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,47 @@
+name: Coverity Scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  coverity:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake build-essential wget
+
+      - name: Download Coverity Build Tool
+        run: |
+          wget -q https://scan.coverity.com/download/cxx/linux64 --post-data "token=${{ secrets.COVERITY_TOKEN }}&project=Argtable3" -O coverity_tool.tgz
+          tar xzf coverity_tool.tgz
+          export COV_DIR=$(find . -type d -name 'cov-analysis*' | head -n 1)
+          echo "COV_DIR=$COV_DIR" >> $GITHUB_ENV
+
+      - name: Build with Coverity
+        run: |
+          mkdir build && cd build
+          cmake ..
+          cd ..
+          $COV_DIR/bin/cov-build --dir cov-int cmake --build build
+
+      - name: Create tarball
+        run: tar czf cov-int.tgz cov-int
+
+      - name: Submit to Coverity Scan
+        env:
+          COVERITY_TOKEN: ${{ secrets.COVERITY_TOKEN }}
+        run: |
+          curl --form token=$COVERITY_TOKEN \
+               --form email=${{ secrets.COVERITY_EMAIL }} \
+               --form file=@cov-int.tgz \
+               --form version="$(date +'%Y-%m-%d')-$(git rev-parse --short HEAD)" \
+               --form description="GitHub Actions Coverity Scan" \
+               https://scan.coverity.com/builds?project=Argtable3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status](https://travis-ci.org/argtable/argtable3.svg?branch=master)](https://travis-ci.org/argtable/argtable3)
+[![clang-tidy](https://github.com/argtable/argtable3/actions/workflows/clang-tidy.yml/badge.svg)](https://github.com/argtable/argtable3/actions/workflows/clang-tidy.yml)
+[![coverity](https://github.com/argtable/argtable3/actions/workflows/coverity.yml/badge.svg)](https://github.com/argtable/argtable3/actions/workflows/coverity.yml)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
 


### PR DESCRIPTION
Adding _Coverity Scan_ helps reduce risk and lower overall project cost by identifying critical quality defects and potential security vulnerabilities during development.