### PR TITLE
build: update CMake min to min...max

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ################################################################################
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...3.10)
 
 ################################################################################
 # Project metadata and build options


### PR DESCRIPTION
Allows build with CMake 4.0.0 without Deprecation Warning.

use the min...max syntax to allow build with newer CMake. 

ref: https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html

Fixes:
```
CMake Deprecation Warning at CMakeLists.txt:31 
(cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```