### PR TITLE
build: limit coverity scan workflow to manul trigger

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,13 +1,11 @@
-name: Coverity Scan
+name: Coverity
 
 on:
-  pull_request:
-  push:
-    branches:
-      - master
+  workflow_dispatch:
 
 jobs:
   coverity:
+    name: Run Coverity Scan
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
_Coverity Scan_ allows up to 28 builds per week and 4 per day for open source projects with fewer than 100K lines of code.

To avoid exceeding this quota, the Coverity Scan workflow is now set to run only on manual trigger. This lets us run scans only when we have fixes for issues found by Coverity, preventing unnecessary builds that would waste the quota.