### PR TITLE
build: add sonarqube workflow for manual code quality scan

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,0 +1,62 @@
+name: SonarQube Analysis
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sonarqube:
+    name: SonarQube Analysis
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake build-essential gcov
+
+      - name: Download build-wrapper
+        run: |
+          wget https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip
+          unzip build-wrapper-linux-x86.zip
+
+      - name: Build with build-wrapper
+        run: |
+          cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="--coverage"
+          ./build-wrapper-linux-x86/build-wrapper-linux-x86-64 --out-dir build_wrapper_output_directory cmake --build build
+
+      - name: Run tests (optional, for coverage)
+        run: |
+          cd build
+          ctest
+
+      - name: SonarQube Scan
+        uses: SonarSource/sonarcloud-github-action@v2
+        with:
+          args: >
+            -Dsonar.projectKey=argtable_argtable3
+            -Dsonar.organization=argtable3
+            -Dsonar.cfamily.build-wrapper-output=build_wrapper_output_directory
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Generate coverage report (optional)
+        run: |
+          gcovr -r . --xml -o coverage.xml || true
+
+      - name: Upload coverage to SonarQube (optional)
+        if: always()
+        uses: SonarSource/sonarcloud-github-action@v2
+        with:
+          args: >
+            -Dsonar.cfamily.build-wrapper-output=build_wrapper_output_directory
+            -Dsonar.coverageReportPaths=coverage.xml
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
This patch adds a _SonarQube_ analysis workflow that can be triggered manually via the GitHub Actions UI. It allows maintainers to run SonarQube scans on demand to assess code quality and coverage for pull requests or any branch, providing valuable insights before merging changes.