### PR TITLE
build: add ci workflow for clang build and test

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -1,0 +1,37 @@
+name: Clang Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  build:
+    name: Build with Clang (${{ matrix.configuration }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        configuration: [Release, Debug]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake clang make
+
+      - name: Configure with CMake (Clang)
+        run: |
+          cmake -B build/${{ matrix.configuration }} \
+            -DCMAKE_BUILD_TYPE=${{ matrix.configuration }} \
+            -DCMAKE_C_COMPILER=clang
+
+      - name: Build with Clang
+        run: cmake --build build/${{ matrix.configuration }} -- -j
+
+      - name: Run tests (fail if any test fails)
+        working-directory: build/${{ matrix.configuration }}
+        run: ctest --output-on-failure


### PR DESCRIPTION
This patch introduces a workflow that verifies argtable3 can be built and tested using the Clang compiler on Ubuntu. Both Debug and Release configurations are built and tested. The workflow ensures Clang compatibility and test coverage on every change.