### PR TITLE
build: add asan memory check ci workflow

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -1,0 +1,33 @@
+name: ASan
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  asan-check:
+    name: AddressSanitizer Memory Check
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+
+    - name: Install Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential cmake
+
+    - name: Build with ASan
+      run: |
+        mkdir -p build
+        cd build
+        cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -fsanitize=address -fno-omit-frame-pointer" ..
+        make
+
+    - name: Run Tests
+      run: |
+        cd build
+        CTEST_OUTPUT_ON_FAILURE=1 make test


### PR DESCRIPTION
This commit adds a GitHub Actions workflow (`asan.yml`) to detect memory issues in the `argtable3` project using AddressSanitizer (ASan). The workflow triggers on `push` and `pull_request` events targeting the `main` branch. It builds the project with ASan and runs tests to identify memory errors, including leaks and invalid accesses.

Purpose:
- Ensure memory safety by detecting issues during CI.
- Improve code quality and reliability with automated checks.